### PR TITLE
Update json-waveform

### DIFF
--- a/bin/json-waveform
+++ b/bin/json-waveform
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# encoding: utf-8
 require "json-waveform"
 require "json"
 require "optparse"


### PR DESCRIPTION
Added utf-8 encoding to fix the following error (Windows 7 32-bit, don't know why this was happening but the encoding was causing the problem).

json-waveform:11: invalid multibyte char (US-ASCII) (SyntaxError)
